### PR TITLE
Fix Azure links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Current build status
 
 <table><tr><td>All platforms:</td>
     <td>
-      <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-        <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/somacore-feedstock?branchName=main">
+      <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=47&branchName=main">
+        <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/somacore-feedstock?branchName=main">
       </a>
     </td>
   </tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,3 +7,7 @@ github:
   user_or_org: TileDB-Inc
   branch_name: main
   tooling_branch_name: main
+azure:
+  build_id: 47
+  user_or_org: TileDB-Inc
+  project_name: CI


### PR DESCRIPTION
This is a documentation-only update to fix the links to the latest Azure build in the README. See PRs https://github.com/TileDB-Inc/tiledb-vcf-feedstock/pull/86 and https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/29 for more details