### PR TITLE
Pin dependencies for python 3.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -23,9 +23,11 @@ requirements:
     - pip
   run:
     - python >=3.7
-    - anndata
+    - anndata       # [py>37]
+    - anndata <0.9  # [py<=37]
     - attrs >=22.1
-    - numba
+    - numba >=0.57 # [py>37]
+    - numba <0.5.7 # [py<=37]
     - numpy >=1.21
     - pandas
     - pyarrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - anndata <0.9  # [py<=37]
     - attrs >=22.1
     - numba >=0.57 # [py>37]
-    - numba <0.5.7 # [py<=37]
+    - numba <0.57 # [py<=37]
     - numpy >=1.21
     - pandas
     - pyarrow


### PR DESCRIPTION
This should allow this to be installable for python 3.7 again.

Hoping this solves the tiledb-soma-feedstock nightly failures: https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=32887&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d

cc: @jdblischak 