### PR TITLE
Only upload binaries from the main branch

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -30,6 +30,7 @@ jobs:
         export sha=$(Build.SourceVersion)
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        export UPLOAD_ON_BRANCH="main"
         if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
           export IS_PR_BUILD="True"
         else

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,3 +6,4 @@ azure:
   build_id: 47
   user_or_org: TileDB-Inc
   project_name: CI
+upload_on_branch: main


### PR DESCRIPTION
Enables submitting a PR from an internal branch without prematurely uploading the conda binary to anaconda.org

cc: @johnkerl 
xref: https://github.com/TileDB-Inc/somacore-feedstock/pull/7#issuecomment-1841560030