### PR TITLE
Add build flags `--no-deps` and `--no-build-isolation`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Shelnutt2 @johnkerl @nguyenv @thetorpedodog
+* @Shelnutt2 @jdblischak @johnkerl @nguyenv @thetorpedodog

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Feedstock Maintainers
 =====================
 
 * [@Shelnutt2](https://github.com/Shelnutt2/)
+* [@jdblischak](https://github.com/jdblischak/)
 * [@johnkerl](https://github.com/johnkerl/)
 * [@nguyenv](https://github.com/nguyenv/)
 * [@thetorpedodog](https://github.com/thetorpedodog/)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,5 +2,30 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
-jobs:
-  - template: ./.azure-pipelines/azure-pipelines-linux.yml
+stages:
+- stage: Check
+  jobs:
+    - job: Skip
+      pool:
+        vmImage: 'ubuntu-22.04'
+      variables:
+        DECODE_PERCENTS: 'false'
+        RET: 'true'
+      steps:
+      - checkout: self
+        fetchDepth: '2'
+      - bash: |
+          git_log=`git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " "`
+          echo "##vso[task.setvariable variable=log]$git_log"
+        displayName: Obtain commit message
+      - bash: echo "##vso[task.setvariable variable=RET]false"
+        condition: and(eq(variables['Build.Reason'], 'PullRequest'), or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]')))
+        displayName: Skip build?
+      - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
+        name: result
+        displayName: Export result
+- stage: Build
+  condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
+  dependsOn: Check
+  jobs:
+    - template: ./.azure-pipelines/azure-pipelines-linux.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,3 +58,4 @@ extra:
     - nguyenv
     - thetorpedodog
     - johnkerl
+    - jdblischak

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:


### PR DESCRIPTION
I was comparing our recipe to the new [conda-forge recipe for somacore](https://github.com/conda-forge/somacore-feedstock/blob/d2114e8965e0c288eceb6df106a0d3c824228b53/recipe/recipe.yaml). I noticed we were not using the build flags `--no-deps` and `--no-build-isolation`, which help ensure that the dependencies are all provided as conda binaries.

Note that I purposefully didn't bump the build number or rerender. Given our limited storage space on anaconda.org, I don't want to upload any binaries that aren't critical. ThisPR is to improve the robustness of our recipe in the long-term, and the changes can go into effect with the next somacore release.